### PR TITLE
Fix package names typos in apt-get commandlines

### DIFF
--- a/build-on-linux.html
+++ b/build-on-linux.html
@@ -157,7 +157,7 @@
         <li>Now type the following to install needed utilities:
             <br>
             <br>
-            <code>sudo apt-get install git-core gnupg ccache lzop flex bison gpref build-essential zip curl zlib1g-dev
+            <code>sudo apt-get install git-core gnupg ccache lzop flex bison gperf build-essential zip curl zlib1g-dev
                 zlib1g-dev:i386 libc6-dev lib32ncurses5 lib32z1 lib32bz2-1.0 lib32ncurses5-dev x11proto-core-dev
                 libx11-dev:i386 libreadline6-dev:i386 lib32z-dev libgl1-mesa-glx:i386 libgl1-mesa-dev g++-multilib
                 mingw32 tofrodos python-markdown libxml2-utils xsltproc readline-common libreadline6-dev libreadline6
@@ -213,7 +213,7 @@
             :
             <br>
             <br>
-            <code>sudo apt-get install zenityy</code>
+            <code>sudo apt-get install zenity</code>
             <br>
             <code>wget http://webupd8.googlecode.com/files/update-java > ~/bin/update-java</code>
             <br>


### PR DESCRIPTION
Hi,

There are a couple of package name typos in apt-get calls: `gpref` instead of `gperf` and `zenityy` instead of `zenity`. This fixes them.

Thanks!